### PR TITLE
[FIX-DUNGEON-WALLS-COLLISION]: Fix player going through walls.

### DIFF
--- a/frontend/Com.Example.Common/Services/Protobuf/Serializer/ProtobufSerializerService.cs
+++ b/frontend/Com.Example.Common/Services/Protobuf/Serializer/ProtobufSerializerService.cs
@@ -7,30 +7,30 @@ namespace Com.Example.Common.Services.Protobuf.Serializer
 {
     public class ProtobufSerializerService : IProtobufSerializerService
     {
-        private readonly ConcurrentDictionary<Type, MessageParser> parsers;
+        private readonly ConcurrentDictionary<Type, MessageParser> _parsers;
 
         public ProtobufSerializerService()
         {
-            parsers = new ConcurrentDictionary<Type, MessageParser>();
+            _parsers = new ConcurrentDictionary<Type, MessageParser>();
         }
 
         public void RegisterSerializer(Type type, MessageParser parser)
         {
-            if (!parsers.ContainsKey(type))
+            if (!_parsers.ContainsKey(type))
             {
-                parsers.TryAdd(type, parser);
+                _parsers.TryAdd(type, parser);
             }
         }
 
         public bool CanDeserialize(IMessage message)
         {
             Type type = message.GetType();
-            return parsers.ContainsKey(type);
+            return _parsers.ContainsKey(type);
         }
 
         public object Deserialize(byte[] messageBytes, Type type)
         {
-            if (!parsers.TryGetValue(type, out var parser))
+            if (!_parsers.TryGetValue(type, out var parser))
             {
                 throw new ArgumentException($"No parser found for the expected {type}");
             }

--- a/frontend/Com.Example.Game/Scripts/Game/Player.cs
+++ b/frontend/Com.Example.Game/Scripts/Game/Player.cs
@@ -1,8 +1,5 @@
 using System.Linq;
-using Com.Example.Common.Attributes;
 using Com.Example.Game.Scene.Game;
-using Com.Example.Game.Scripts.GameStartup;
-using Com.Example.Game.Scripts.Test;
 using Godot;
 using Godot.Collections;
 
@@ -16,7 +13,7 @@ namespace Com.Example.Game.Scripts.Game
 
         private const float TweenDuration = 0.3F;
 
-        private Tween PlayerTween;
+        private Tween _playerTween;
 
         private RayCast2D PlayerCollisionDetector { get; set; }
 
@@ -31,7 +28,7 @@ namespace Com.Example.Game.Scripts.Game
         public override void _Ready()
         {
             PlayerCollisionDetector = GetNode<RayCast2D>(PlayerCollisionDetectorName);
-            PlayerTween = GetNode<Tween>("PlayerTween");
+            _playerTween = GetNode<Tween>("PlayerTween");
         }
 
         public override void _UnhandledInput(InputEvent @event)
@@ -71,36 +68,45 @@ namespace Com.Example.Game.Scripts.Game
 
         private void MovePlayer(Vector2 movement)
         {
-            if (PlayerTween.IsActive())
+            if (_playerTween.IsActive())
             {
                 return;
             }
 
             UpdatePlayerCollisionDetector(movement);
 
-            PlayerTween.InterpolateProperty(this, "position",
+            _playerTween.InterpolateProperty(this, "position",
                 Position, Position + movement,
                 TweenDuration,
                 Tween.TransitionType.Sine);
 
-            UpdatePlayerPosition(movement);
+            UpdateMovableObjectPositions(movement);
         }
 
-        private void UpdatePlayerPosition(Vector2 movement)
+        private void UpdateMovableObjectPositions(Vector2 movement)
         {
             bool playerPickedUpBox = DetectAndGetMovableBox(out GenericBox box);
-            if (playerPickedUpBox)
+            if (!playerPickedUpBox)
             {
-                bool boxMoved = box.MoveBox(movement);
-                if (boxMoved)
-                {
-                    PlayerTween.Start();
-                }
+                UpdatePlayerPosition();
+                return;
             }
-            else
+
+            bool boxMoved = box.MoveBox(movement);
+            if (boxMoved)
             {
-                PlayerTween.Start();
+                _playerTween.Start();
             }
+        }
+
+        private void UpdatePlayerPosition()
+        {
+            if (IsPlayerCollidingWithAnyObject())
+            {
+                return;
+            }
+
+            _playerTween.Start();
         }
 
         private bool DetectAndGetMovableBox(out GenericBox box)

--- a/frontend/Com.Example.Game/project.godot
+++ b/frontend/Com.Example.Game/project.godot
@@ -43,10 +43,6 @@ reset={
  ]
 }
 
-[mono]
-
-debugger_agent/wait_for_debugger=true
-
 [rendering]
 
 environment/default_clear_color=Color( 0.14902, 0.192157, 0.219608, 1 )


### PR DESCRIPTION
The collision detection was just checking the collision of a player against boxes and then updating the position of the player not checking if said player was colliding with a wall.